### PR TITLE
Switch to add_parsable_certificates method to add native root certs

### DIFF
--- a/rust/sbd-client/src/raw_client.rs
+++ b/rust/sbd-client/src/raw_client.rs
@@ -240,11 +240,10 @@ fn priv_system_tls(
         not(feature = "force_webpki_roots"),
         any(target_os = "windows", target_os = "linux", target_os = "macos",),
     ))]
-    for cert in rustls_native_certs::load_native_certs()
-        .expect("failed to load system tls certs")
-    {
-        roots.add(cert).expect("failed to add cert to root");
-    }
+    roots.add_parsable_certificates(
+        rustls_native_certs::load_native_certs()
+            .expect("failed to load system tls certs"),
+    );
 
     if danger_disable_certificate_check {
         let v = rustls::client::WebPkiServerVerifier::builder(Arc::new(roots))


### PR DESCRIPTION
Addresses https://github.com/holochain/holochain/issues/4418

The fact that sbd is using a newer version of webpki-roots allows the code to be a bit more slick than in the corresponding [tx5 PR](https://github.com/holochain/tx5/pull/114).