### PR TITLE
backport #42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1374,12 +1374,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -1529,9 +1528,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1542,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hyper-util = "0.1.3"
 rand = "0.8.5"
 rcgen = "0.13.1"
 rustls = "0.22.4"
-rustls-native-certs = "0.7.0"
+rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.1.2"
 slab = "0.4.9"
 sodoken = { version = "0.0.901-alpha", default-features = false }

--- a/rust/sbd-client/src/raw_client.rs
+++ b/rust/sbd-client/src/raw_client.rs
@@ -241,8 +241,7 @@ fn priv_system_tls(
         any(target_os = "windows", target_os = "linux", target_os = "macos",),
     ))]
     roots.add_parsable_certificates(
-        rustls_native_certs::load_native_certs()
-            .expect("failed to load system tls certs"),
+        rustls_native_certs::load_native_certs().certs,
     );
 
     if danger_disable_certificate_check {


### PR DESCRIPTION
Backports #42 to the new `release-0.0.x-alpha` branch that had been branched off from the [0.0.8-alpha tag](https://github.com/holochain/sbd/releases/tag/sbd-client-v0.0.8-alpha)