### PR TITLE
bump version to 0.0.12-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-bench"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-client"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-e2e-crypto-client"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "sbd-client",
  "sbd-server",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-o-bahn-client-tester"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "hex",
  "sbd-server",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-o-bahn-server-tester"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "sbd-client",
  "tokio",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-server"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 dependencies = [
  "anstyle",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ panic = "abort"
 
 [workspace.dependencies]
 # workspace member deps
-sbd-bench = { version = "0.0.9-alpha", path = "rust/sbd-bench" }
-sbd-client = { version = "0.0.9-alpha", path = "rust/sbd-client" }
-sbd-e2e-crypto-client = { version = "0.0.9-alpha", path = "rust/sbd-e2e-crypto-client" }
-sbd-o-bahn-client-tester = { version = "0.0.9-alpha", path = "rust/sbd-o-bahn-client-tester" }
-sbd-o-bahn-server-tester = { version = "0.0.9-alpha", path = "rust/sbd-o-bahn-server-tester" }
-sbd-server = { version = "0.0.9-alpha", path = "rust/sbd-server" }
+sbd-bench = { version = "0.0.12-alpha", path = "rust/sbd-bench" }
+sbd-client = { version = "0.0.12-alpha", path = "rust/sbd-client" }
+sbd-e2e-crypto-client = { version = "0.0.12-alpha", path = "rust/sbd-e2e-crypto-client" }
+sbd-o-bahn-client-tester = { version = "0.0.12-alpha", path = "rust/sbd-o-bahn-client-tester" }
+sbd-o-bahn-server-tester = { version = "0.0.12-alpha", path = "rust/sbd-o-bahn-server-tester" }
+sbd-server = { version = "0.0.12-alpha", path = "rust/sbd-server" }
 # crate deps
 anstyle = "1.0.6"
 base64 = "0.22.0"

--- a/rust/sbd-bench/Cargo.toml
+++ b/rust/sbd-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbd-bench"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 edition = "2021"
 
 [dependencies]

--- a/rust/sbd-client/Cargo.toml
+++ b/rust/sbd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbd-client"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 description = "simple websocket-based message relay client"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/sbd"

--- a/rust/sbd-e2e-crypto-client/Cargo.toml
+++ b/rust/sbd-e2e-crypto-client/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/sbd-e2e-crypto-client"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 keywords = ["holochain", "holo", "p2p", "networking"]
 categories = ["network-programming"]
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 edition = "2021"
 
 [dependencies]

--- a/rust/sbd-o-bahn-client-tester/Cargo.toml
+++ b/rust/sbd-o-bahn-client-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbd-o-bahn-client-tester"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 description = "simple websocket-based message relay client tester"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/sbd"

--- a/rust/sbd-o-bahn-server-tester/Cargo.toml
+++ b/rust/sbd-o-bahn-server-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbd-o-bahn-server-tester"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 description = "simple websocket-based message relay server tester"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/sbd"

--- a/rust/sbd-server/Cargo.toml
+++ b/rust/sbd-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbd-server"
-version = "0.0.9-alpha"
+version = "0.0.12-alpha"
 description = "simple websocket-based message relay server"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/sbd"


### PR DESCRIPTION
This is for use in holochain 0.4 without cargo auto-upgrading to 0.0.9-alpha2.