### PR TITLE
build: pin hyper to 1.7.0 to workaround upstream issue where axum-server fails to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,13 +1017,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1031,6 +1032,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2163,6 +2165,7 @@ dependencies = [
  "ed25519-dalek",
  "escargot",
  "futures",
+ "hyper",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/rust/sbd-server/Cargo.toml
+++ b/rust/sbd-server/Cargo.toml
@@ -20,6 +20,9 @@ axum = { workspace = true, default-features = false, features = [
   "ws",
 ] }
 axum-server = { workspace = true, features = [ "tls-rustls" ] }
+# Pin hyper to workaround issue where axum-server fails to compile.
+# TODO Remove this when upstream issue is resolved: https://github.com/programatik29/axum-server/issues/170
+hyper = "=1.7.0"
 base64 = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = [ "color", "derive", "wrap_help" ] }


### PR DESCRIPTION
Resolves https://github.com/holochain/kitsune2/issues/371

See https://github.com/programatik29/axum-server/issues/170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server dependencies to a fixed version to resolve build compatibility issues and improve system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->