### PR TITLE
chore: Prepare next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## \[[0.3.4](https://github.com/holochain/sbd/compare/v0.3.3...v0.3.4)\] - 2025-11-13
+
+### Features
+
+- Add basic OTLP metics to the sbd-server that can be exported to a metrics server with the new CLI flag `--otlp-endpoint` by @ThetaSinner in [#64](https://github.com/holochain/sbd/pull/64)
+
+### Build System
+
+- Pin hyper to 1.7.0 to workaround upstream issue where axum-server fails to compile. See https://github.com/programatik29/axum-server/issues/170 (#65) by @mattyg in [#65](https://github.com/holochain/sbd/pull/65)
+
+### First-time Contributors
+
+- @mattyg made their first contribution in [#65](https://github.com/holochain/sbd/pull/65)
 
 ## [0.3.3] - 2025-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-client"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-e2e-crypto-client"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "sbd-client",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-o-bahn-client-tester"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "hex",
  "sbd-server",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-o-bahn-server-tester"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "sbd-client",
  "tokio",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "sbd-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anstyle",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/sbd"


### PR DESCRIPTION
I manually ran holochain_release_util locally to generate the git-cliff changelog, because builds on the current version (0.3.3) are failing due to #65, and thus [the github action prepare-release fails](https://github.com/holochain/sbd/actions/runs/19337604215/job/55316894223).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes - Version 0.3.4

* **New Features**
  * Added OTLP metrics export capability for sbd-server with configurable endpoint via new CLI flag.

* **Build System**
  * Updated build dependencies to improve compilation stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->